### PR TITLE
fix: added showConsentsTab option + FE Recaptcha config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,11 @@ export type ShowPreferenceOptions = {
    * supportedCountries is the list of supported ISO 3166 ALPHA-2 country codes to show in the rights form
    */
   supportedCountries?: string[]
+
+  /**
+   * showConsentsTab determines whether the consents tab will show. If undefined, the consents tab is displayed
+   */
+  showConsentsTab?: boolean
 }
 
 /**
@@ -836,6 +841,7 @@ export interface RightsTab {
   bodyTitle?: string
   bodyDescription?: string
   buttonText: string
+  recaptchaEnabled?: boolean
 
   /**
    * additional extensions
@@ -1212,6 +1218,21 @@ export interface Configuration {
    * Plugins configured for the configuration
    */
   plugins?: { [key: string]: any }
+
+  /**
+   * Recaptcha config
+   */
+  recaptcha?: Recaptcha
+}
+
+/**
+ * Recaptcha interface defines the Recaptcha config
+ */
+export interface Recaptcha {
+  /**
+   * siteKey: Recaptcha site/public key used to exchange for a reCaptcha token
+   */
+  siteKey?: string
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> added showConsentsTab option + FE Recaptcha config

## Why is this change being made?
- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested w/ importing the local lib into lanyard and ketch-tag and building them successfully

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[KD-5322](https://ketch-com.atlassian.net/browse/KD-5322)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
