### PR TITLE
feat(KD-8225): Rights Form V2

### DIFF
--- a/src/forms.ts
+++ b/src/forms.ts
@@ -1,0 +1,119 @@
+/**
+ * ExperienceFormField: Describes a form field in the user experience.
+ */
+export interface ExperienceFormField {
+  id?: string
+  required?: boolean
+  label?: string
+  hint?: string
+  category?: FormFieldCategory
+  type?: FormFieldType
+  variant?: FormFieldVariant
+  maxLength?: number
+  name?: string
+  width?: FormFieldWidth
+  identitySpaceCode?: string
+  options?: FormFieldDropdownOption[]
+}
+
+/**
+ * FormFieldDropdownOption: Describes an option in a dropdown form field.
+ */
+export type FormFieldDropdownOption = {
+  label?: string
+  value?: string
+}
+
+/**
+ * FormFieldWidth: Describes the width of the form field in Rights Form.
+ *
+ * @enum
+ * @values UNSPECIFIED = width is unspecified
+ *          HALF = half width
+ *          FULL = full width
+ */
+export enum FormFieldWidth {
+  UNSPECIFIED = 'unspecified',
+  HALF = 'half',
+  FULL = 'full',
+}
+
+/**
+ * FormFieldCategory: Describes the category of the form field in Rights Form.
+ *
+ * @enum
+ * @values UNSPECIFIED = category is unspecified
+ *          DEFAULT = default field (ex: firstName, lastName, email etc.)
+ *          CUSTOM = user created form field
+ */
+export enum FormFieldCategory {
+  UNSPECIFIED = 'unspecified',
+  DEFAULT = 'default',
+  CUSTOM = 'custom',
+}
+
+/**
+ * FormFieldType: Describes the type of the form field in Rights Form.
+ *
+ * @enum
+ * @values UNSPECIFIED = type is unspecified
+ *          TEXT = text field
+ *          DROPDOWN = dropdown field
+ *          CHECKBOX = checkbox field
+ */
+export enum FormFieldType {
+  UNSPECIFIED = 'unspecified',
+  TEXT = 'text',
+  DROPDOWN = 'dropdown',
+  CHECKBOX = 'checkbox',
+}
+
+/**
+ * FormFieldVariant: Describes the variant of a text field in Rights Form.
+ *
+ * @enum
+ * @values UNSPECIFIED = variant is unspecified
+ *          INPUT = input variant
+ *          TEXTAREA = textarea variant
+ */
+export enum FormFieldVariant {
+  UNSPECIFIED = 'unspecified',
+  INPUT = 'input',
+  TEXTAREA = 'textarea',
+}
+
+/**
+ * CanonicalRightForm: Represents the mapping between canonical right code and form template ID.
+ */
+export interface CanonicalRightForm {
+  canonicalRightCode: string
+  formTemplateID: string
+}
+
+/**
+ * CustomRightForm: Represents the mapping between a custom right code and form template ID.
+ */
+export interface CustomRightForm {
+  rightCode: string
+  formTemplateID: string
+}
+
+/**
+ * FormSection: Describes a section of a form, including its title, description and form fields.
+ */
+export interface FormSection {
+  description: string
+  formFields: ExperienceFormField[]
+  title: string
+}
+
+/**
+ * FormTemplate: Describes a form template including its id, code, name, title and sections.
+ */
+export interface FormTemplate {
+  code: string
+  id: string
+  name: string
+  sections: FormSection[]
+  title: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { ExperienceFormField, CanonicalRightForm, CustomRightForm, FormTemplate } from './forms'
+
 /**
  * Tab
  *
@@ -680,92 +682,6 @@ export interface JIT {
 }
 
 /**
- * ExperienceFormField
- */
-export interface ExperienceFormField {
-  id?: string
-  required?: boolean
-  label?: string
-  hint?: string
-  category?: FormFieldCategory
-  type?: FormFieldType
-  variant?: FormFieldVariant
-  maxLength?: number
-  name?: string
-  width?: FormFieldWidth
-  identitySpaceCode?: string
-  options?: FormFieldDropdownOption[]
-}
-
-/**
- * FormFieldDropdownOption
- */
-export type FormFieldDropdownOption = {
-  label?: string
-  value?: string
-}
-
-/**
- * FormFieldWidth describes the width of the form field in Rights Form
- *
- * unspecified = width is unspecified
- * half = half width
- * full = full width
- *
- * @enum
- */
-export enum FormFieldWidth {
-  UNSPECIFIED = 'unspecified',
-  HALF = 'half',
-  FULL = 'full',
-}
-
-/**
- * FormFieldCategory describes the category of the form field in Rights Form
- *
- * unspecified = category is unspecified
- * default = default field (ex: firstName, lastName, email etc.)
- * custom = user created form field
- *
- * @enum
- */
-export enum FormFieldCategory {
-  UNSPECIFIED = 'unspecified',
-  DEFAULT = 'default',
-  CUSTOM = 'custom',
-}
-
-/**
- * FormFieldType describes the type of the form field in Rights Form
- *
- * unspecified = category is unspecified
- * text = text field
- * dropdown = dropdown field
- *
- * @enum
- */
-export enum FormFieldType {
-  UNSPECIFIED = 'unspecified',
-  TEXT = 'text',
-  DROPDOWN = 'dropdown',
-}
-
-/**
- * FormFieldVariant describes the variant of a text field in Rights Form
- *
- * unspecified = unspecified variant
- * input = input variant
- * textarea = textarea variant
- *
- * @enum
- */
-export enum FormFieldVariant {
-  UNSPECIFIED = 'unspecified',
-  INPUT = 'input',
-  TEXTAREA = 'textarea',
-}
-
-/**
  * RightsTab
  */
 export interface RightsTab {
@@ -979,6 +895,7 @@ export interface Right {
    * data subject types
    */
   dataSubjectTypeCodes?: string[]
+  canonicalRightCode: string
 }
 
 /**
@@ -1245,6 +1162,10 @@ export interface Configuration {
    * Recaptcha config
    */
   recaptcha?: Recaptcha
+
+  canonicalRightForms?: CanonicalRightForm[]
+  customRightForms?: CustomRightForm[]
+  formTemplates: FormTemplate[]
 }
 
 /**
@@ -2286,3 +2207,16 @@ export enum ButtonVariant {
   Outlined = 'outlined',
   Contained = 'contained',
 }
+
+export {
+  ExperienceFormField,
+  FormFieldDropdownOption,
+  FormFieldWidth,
+  FormFieldCategory,
+  FormFieldType,
+  FormFieldVariant,
+  CanonicalRightForm,
+  CustomRightForm,
+  FormSection,
+  FormTemplate,
+} from './forms'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> feat(KD-8225): adds experience form templates; 
> chore(KD-8225): abstracts form types;

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes were tested locally in Lanyard:
![Screenshot 2023-07-05 at 10 04 21 PM](https://github.com/ketch-sdk/ketch-types/assets/3360265/6f09d261-dc00-4125-81bb-1cce4a834b0f)
![Screenshot 2023-07-05 at 10 03 30 PM](https://github.com/ketch-sdk/ketch-types/assets/3360265/131f5115-a517-4c2a-8c5d-626226603434)

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://ketch-com.atlassian.net/browse/KD-8225



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
