### PR TITLE
fix: add no_rights_available translation to v2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4371,6 +4371,7 @@ export interface BaseStaticContentConfig {
   legal_text?: string
   marketing?: string
   maximum_storage?: string
+  no_rights_available?: string
   object_to_legitimate_interest?: string
   of?: string
   off?: string


### PR DESCRIPTION
see https://github.com/ketch-sdk/ketch-types/pull/178

this adds the translation to the correct location for v2 config