### PR TITLE
fix: move unsub all position to exp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3142,6 +3142,7 @@ export interface PreferenceFooterThemeConfig {
  */
 
 export interface PreferenceContainerThemeConfig {
+  exitPosition?: ExitButtonPosition
   font?: string
   background?: ColorThemeConfig
 }
@@ -3874,7 +3875,6 @@ export interface PreferenceExperienceTabsLayoutConfig {
 
 export interface PreferenceExperienceLayoutConfig {
   gpcBadgeVisible?: boolean
-  exitPosition?: ExitButtonPosition
   tabs?: PreferenceExperienceTabsLayoutConfig
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3291,7 +3291,6 @@ export enum UnsubscribeFromAllPosition {
  */
 
 export interface SubscriptionsTabUnsubscribeAllThemeConfig {
-  position?: UnsubscribeFromAllPosition
   background?: ColorThemeConfig
   text?: ColorThemeConfig
   cornerRadius?: number
@@ -3735,6 +3734,7 @@ export interface SubscriptionsTabUnsubscribeAllExperienceLayoutConfig {
   description: UnsubscribeAllDescriptionExperienceLayoutConfig
   switchButton: SwitchButtonsExperienceLayoutConfig
   impact: UnsubscribeAllImpact
+  position?: UnsubscribeFromAllPosition
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Moves the unsubscribe all position config from theme to experience

## Why is this change being made?
- [x] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://ketch-com.atlassian.net/browse/KD-12332

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
