### PR TITLE
fix: close w/o setting consent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export enum ExperienceClosedReason {
   SET_CONSENT = 'setConsent',
   INVOKE_RIGHT = 'invokeRight',
   CLOSE = 'close',
+  CLOSE_WITHOUT_SETTING_CONSENT = 'closeWithoutSettingConsent',
   WILL_NOT_SHOW = 'willNotShow',
   SET_SUBSCRIPTIONS = 'setSubscriptions',
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> instruct ketch-tag to close the experience without overriding consent that may have been updated by a submitted dsr

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
build

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://ketch-com.atlassian.net/browse/KD-13064

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
