### PR TITLE
feat: fab button experience type and method to see if experience is displayed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1191,6 +1191,7 @@ export interface AccessibilityButtonConfiguration {
   color: string
   icon: string
   position: 'bottom-left' | 'bottom-right'
+  experienceDisplayType: ExperienceDisplayType
 }
 
 /**
@@ -2552,6 +2553,11 @@ export interface Ketch {
    * Get the region information
    */
   getRegionInfo(): Promise<string>
+
+  /**
+   * Check if an experience is currently showing
+   */
+  getIsExperienceDisplayed(): Promise<boolean>
 
   /**
    * Alias for `emitter.on(eventName, listener)`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2557,7 +2557,7 @@ export interface Ketch {
   /**
    * Check if an experience is currently showing
    */
-  getIsExperienceDisplayed(): Promise<boolean>
+  getIsExperienceDisplayed(): boolean
 
   /**
    * Alias for `emitter.on(eventName, listener)`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Adds a experience display type to the fab button config so we can support showing banner, modal, or pref when the button is clicked
- Adds a method to ketch tag type which will return the value of `Ketch._isExperienceDisplayed`, so that we can reliably know in lanyard if an experience is currently shown and render the fab button accordingly

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://ketch-com.atlassian.net/browse/KD-13653

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
