### PR TITLE
fix(tcf): explicit types for config.systems and purpose.systems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -614,6 +614,9 @@ export interface ConfigSystems {
 
 /**
  * Purpose Systems
+ *
+ * The systems field on a purpose contains a list of IDs associated with the purpose. See the
+ * ConfigurationV2.systems field for details on each system.
  */
 export interface PurposeSystems {
   [key: string]: string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -606,10 +606,17 @@ export type PurposeCategory = {
 }
 
 /**
- * Systems
+ * Config Systems
  */
-export interface Systems {
-  [key: string]: any[]
+export interface ConfigSystems {
+  [key: string]: TCFSystem[]
+}
+
+/**
+ * Purpose Systems
+ */
+export interface PurposeSystems {
+  [key: string]: string[]
 }
 
 /**
@@ -632,7 +639,7 @@ export interface Purpose {
   legalBasisName?: string
   legalBasisDescription?: string
   illustrations?: string[]
-  systems?: Systems
+  systems?: PurposeSystems
 
   /**
    * the data subject types for which the purpose is relevant. If this list is empty then the purpose applies to all
@@ -1422,7 +1429,7 @@ export interface ConfigurationV2 {
     }
   }
 
-  systems?: Systems
+  systems?: ConfigSystems
 }
 
 /**
@@ -1563,7 +1570,7 @@ export interface Configuration {
    */
   isConfigPaused?: boolean
 
-  systems?: Systems
+  systems?: ConfigSystems
 }
 
 export interface Translations {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Adds explicit types for config.systems and purpose.systems, instead of `any`. This is related to issues with vendor opt in/out since we switched to using the config.systems field in lanyard, where we used to use config.vendors.

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
