### PR TITLE
feat(gpp): isGpcEnabled field in consent objects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -367,6 +367,7 @@ export type Consent = {
   vendors?: string[] // list of vendor ids for which the user has opted out
   googleVendors?: string[] // list of Google vendor ids for which the user has opted out
   protocols?: Protocols
+  isGpcEnabled?: boolean
 }
 
 /**
@@ -2390,6 +2391,7 @@ export interface GetConsentRequest {
   googleVendors?: string[]
 
   collectedAt?: number
+  isGpcEnabled?: boolean
 }
 
 /**
@@ -2430,6 +2432,7 @@ export interface SetConsentRequest {
    */
   vendors?: string[]
   googleVendors?: string[]
+  isGpcEnabled?: boolean
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Consent object and get/put consent request objects need to take in the isGpcEnabled flag to support GPC bits in the GPP protocol string

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/ketch-com/wheelhouse/pull/831
- https://github.com/ketch-com/shoreline/pull/225 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
