### PR TITLE
fix: modal close button consent source

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2423,8 +2423,7 @@ export enum ConsentSource {
   ModalRejectAll = 'modal.rejectAll',
   ModalDefault = 'modal.default', // Clicked save without changing purpose choices
   ModalManual = 'modal.manual', // Changed some purposes then clicked save
-  ModalCloseButtonDefault = 'modal.closeButton.default', // Clicked the close button without changing purpose choices
-  ModalCloseButtonManual = 'modal.closeButton.manual', // Changed some purposes then clicked the close button
+  ModalCloseButton = 'modal.closeButton', // Clicked close button in modal
   PreferenceConsentsTabAcceptAll = 'preference.consentsTab.acceptAll',
   PreferenceConsentsTabRejectAll = 'preference.consentsTab.rejectAll',
   PreferenceDefault = 'preference.default', // Clicked save without changing anything


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Fixes modal close button consent source - there should only be one close button source as there's no difference in the consent that is set when you click the X button

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
