### PR TITLE
feat(experience): add Consent Gate experience to types 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5295,20 +5295,9 @@ export type ConsentGateExperienceHeaderContent = {
  * Consent Gate Experience Consent Block Content Configuration
  */
 
-export type ConsentGateExperienceConsentBlockPurposesListSwitchButtonLabelsContent = {
-  onText: string
-  offText: string
-  alwaysOnText: string
-}
-
-export type ConsentGateExperienceConsentBlockPurposesListBulkActionButtonsContent = {
-  acceptAllText: string
-  rejectAllText: string
-}
-
 export type ConsentGateExperienceConsentBlockPurposesListPurposesContent = {
-  switchButtonLabels: ConsentGateExperienceConsentBlockPurposesListSwitchButtonLabelsContent
-  bulkActionButtons: ConsentGateExperienceConsentBlockPurposesListBulkActionButtonsContent
+  switchButtonLabels: SwitchButtonsExperienceContentConfig
+  bulkActionButtons: BulkActionButtonsExperienceContentConfig
 }
 
 export type ConsentGateExperienceConsentBlockPurposesListContent = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> In order to properly create the new 'Consent Gate' experience in figurehead, it must be added to ketch-types. figurehead 'ExperienceV2DTO' calls 'ExperienceLayoutConfig' and 'ExperienceContentConfig' from ketch-types in order to define its corresponding "layout" and "translations" fields. Without this change, the new Consent Gate experience is being left as an "undefined" type with null layout and translations. Some changes in index.ts may not be necessary (such as lines 39 and 52), but I kept them just in case.

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.