### PR TITLE
feat: add name, jurisdictionName, and regions to JurisdictionInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -704,6 +704,9 @@ export interface JurisdictionInfo {
   defaultJurisdictionCode?: string
   variable?: string
   jurisdictions?: { [key: string]: string }
+  name?: string
+  jurisdictionName?: string
+  regions?: { [key: string]: { name: string; jurisdictionCode: string; jurisdictionName: string } }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -5447,6 +5447,7 @@ interface CountryTranslations {
 export interface BaseStaticContentConfig {
   accept_all?: string
   accept?: string
+  always_active?: string
   and_the?: string
   and?: string
   apply?: string


### PR DESCRIPTION
## Description of this change

> Adds display name fields to `JurisdictionInfo` to support `{{region}}` and `{{jurisdiction}}` template variable substitution in lanyard experiences.
>
> - Add `name?` — region display name (e.g. "California")
> - Add `jurisdictionName?` — jurisdiction display name (e.g. "US - California")
> - Add `regions?` — map of region codes to display name data, sourced from boot.js

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Verified ketch-tag enriches cfg.jurisdiction with name and jurisdictionName from boot.js regions map
> - Confirmed values flow through to lanyard banner and render correctly in place of {{region}} and {{jurisdiction}}

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.