### PR TITLE
chore: auto-bump semaphore ketch-types dependency on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    outputs:
+      version-patch: ${{ format('{0}.{1}.{2}', steps.version.outputs.version-major-only, steps.version.outputs.version-minor-only, steps.version.outputs.version-patch-only) }}
+
     permissions:
       contents: write    # Required to create releases
       id-token: write    # Required for npm OIDC Trusted Publishing
@@ -104,6 +107,102 @@ jobs:
         uses: conventional-actions/create-release@c025b7306d14a25901b72486f97f3ebe7662a8ed # v1.0.31
         with:
           tag_name: ${{ steps.version.outputs.version }}
+
+  bump-semaphore:
+    name: Bump semaphore ketch-types dependency
+    needs: [build, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout semaphore
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: ketch-com/semaphore
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+
+      - name: Setup npmrc for ketch-com
+        uses: conventional-actions/setup-npmrc@e851e66a09d6ad9301d4c7604f3493f90febef10 # v1
+        with:
+          always-auth: true
+          scope: ketch-com
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Bump ketch-types version
+        run: npm pkg set dependencies.@ketch-sdk/ketch-types="^${{ needs.release.outputs.version-patch }}"
+
+      - name: Update package-lock.json
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Import GPG key
+        uses: conventional-actions/import-gpg@e14bec88da3bf2dcb7949ee51dc6087630664928 # v1.0.2
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Create branch and commit
+        run: |
+          VERSION="${{ needs.release.outputs.version-patch }}"
+          BRANCH="chore/bump-ketch-types-${VERSION}"
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json
+          git commit -m "chore: bump ketch-types to ${VERSION}"
+          git push origin "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Close stale bump PRs
+        run: |
+          gh pr list \
+            --repo ketch-com/semaphore \
+            --search "chore: bump ketch-types in:title" \
+            --state open \
+            --json number \
+            --jq '.[].number' | \
+          xargs -r -I {} gh pr close {} \
+            --repo ketch-com/semaphore \
+            --comment "Superseded by newer version bump"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Create PR
+        run: |
+          VERSION="${{ needs.release.outputs.version-patch }}"
+          gh pr create \
+            --repo ketch-com/semaphore \
+            --title "chore: bump ketch-types to ${VERSION}" \
+            --body "## Description of this change
+          > Bumps ketch-types to ${VERSION}
+
+          ## Why is this change being made?
+          - [x] Chore (non-functional changes)
+          - [ ] Bug fix (non-breaking change that fixes an issue)
+          - [ ] New feature (non-breaking change that adds functionality)
+          - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+          ## How was this tested? How can the reviewer verify your testing?
+          > Automated dependency bump
+
+          ## Related issues
+
+          ## Checklist
+          - [ ] I have added tests to cover my changes.
+          - [x] All new and existing tests passed.
+          - [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
+          - [x] I have informed stakeholders of my changes." \
+            --assignee alexchavez1 \
+            --head "chore/bump-ketch-types-${VERSION}" \
+            --base main
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,6 @@ jobs:
           - [x] All new and existing tests passed.
           - [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
           - [x] I have informed stakeholders of my changes." \
-            --assignee alexchavez1 \
             --head "chore/bump-ketch-types-${VERSION}" \
             --base main
         env:


### PR DESCRIPTION
## Description of this change

> Adds a CI job that automatically opens a semaphore PR to bump the @ketch-sdk/ketch-types dependency after each release.
>
> - Adds `outputs` to the `release` job to expose the version for downstream jobs
> - Adds `bump-semaphore` job to CI, triggered after `build` and `release` complete
> - Job checks out semaphore, bumps the ketch-types version, GPG-signs the commit, and opens a PR
> - Closes any stale previous ketch-types bump PRs before opening the new one

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Verified same pattern works in lanyard, ketch-plugins, and ketch-tag CI today
> - No logic changes — purely additive CI job plus one outputs block on the release job

## Related issues

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.