### PR TITLE
feat(KD-16888): add AgeBand interface and ageBands field to Purpose

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -804,6 +804,12 @@ export interface ConfigSystems {
  * The systems field on a purpose contains a list of IDs associated with the purpose. See the
  * ConfigurationV2.systems field for details on each system.
  */
+export interface AgeBand {
+  ageLower: number
+  ageUpper: number
+  legalBasisCode: string
+}
+
 export interface PurposeSystems {
   [key: string]: string[]
 }
@@ -841,6 +847,8 @@ export interface Purpose {
    * the canonical purposes (ketch purposes) assigned to this purpose
    */
   canonicalPurposeCodes?: string[]
+
+  ageBands?: AgeBand[]
 }
 
 /**


### PR DESCRIPTION
## Description of this change

Adds `AgeBand` interface and `ageBands?: AgeBand[]` field to the `Purpose` interface to support the age bands feature (KD-16888).

- Add `AgeBand` interface with `ageLower`, `ageUpper`, and `legalBasisCode` fields
- Add optional `ageBands` field to `Purpose` interface

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Tested locally:

- Types consumed in ketch-tag age bands feature
- Removes need for local `PurposeWithAgeBands` extension type and unsafe cast

## Related issues

[KD-16888](https://ketch-com.atlassian.net/browse/KD-16888)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

[KD-16888]: https://ketch-com.atlassian.net/browse/KD-16888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ