### PR TITLE
feat(profile): Add collection and subscription types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3429,16 +3429,38 @@ export interface ProfilePreferencesContext {
 }
 
 /**
+ * ProfileSubscriptionTopicSetting
+ */
+export type ProfileSubscriptionTopicSetting = Record<string, { status: 'granted' | 'denied' }>
+
+/**
+ * ProfileSubscriptionControlSetting
+ */
+export interface ProfileSubscriptionControlSetting {
+  status: 'granted' | 'denied'
+}
+
+/**
+ * ProfileSubscriptions
+ */
+export interface ProfileSubscriptions {
+  topics?: Record<string, ProfileSubscriptionTopicSetting>
+  controls?: Record<string, ProfileSubscriptionControlSetting>
+}
+
+/**
  * PutProfileRequest
  */
 export interface PutProfileRequest {
   organizationCode: string
+  controllerCode?: string
   propertyCode: string
   environmentCode?: string
   jurisdictionCode: string
   languageCode: string
   identities: ProfilePreferencesIdentity[]
-  attributes: ProfilePreferencesAttribute[]
+  attributes?: ProfilePreferencesAttribute[]
+  subscriptions?: ProfileSubscriptions
   context: ProfilePreferencesContext
   accountId?: string
   regionCode?: string
@@ -3449,6 +3471,7 @@ export interface PutProfileRequest {
  */
 export interface GetProfileRequest {
   organizationCode: string
+  controllerCode?: string
   propertyCode: string
   environmentCode?: string
   jurisdictionCode: string
@@ -3462,7 +3485,13 @@ export interface GetProfileRequest {
  * GetProfileResponse
  */
 export interface GetProfileResponse {
+  controllerCode?: string
+  propertyCode?: string
+  environmentCode?: string
+  jurisdictionCode?: string
+  regionCode?: string
   attributes?: ProfilePreferencesAttribute[]
+  subscriptions?: ProfileSubscriptions
 }
 
 /**
@@ -3516,10 +3545,81 @@ export interface ProfileAttribute {
 }
 
 /**
+ * ProfileCollectionItemType
+ */
+export type ProfileCollectionItemType = 'attribute' | 'subscription_topic' | 'subscription_control'
+
+/**
+ * ProfileCollectionItem
+ */
+export interface ProfileCollectionItem {
+  type: ProfileCollectionItemType
+  code: string
+  id?: string
+  order: number
+}
+
+/**
+ * ProfileCollectionSection
+ */
+export interface ProfileCollectionSection {
+  code: string
+  name: string
+  displayName: string
+  displayNameTranslations?: Record<string, string>
+  items: ProfileCollectionItem[]
+  order: number
+}
+
+/**
+ * ProfileCollection
+ */
+export interface ProfileCollection {
+  code: string
+  name: string
+  displayName: string
+  displayNameTranslations?: Record<string, string>
+  description?: string
+  descriptionTranslations?: Record<string, string>
+  sections: ProfileCollectionSection[]
+}
+
+/**
+ * ProfileConfigTopic
+ */
+export interface ProfileConfigTopic {
+  code: string
+  name: string
+  description: string
+  contactMethods?: string[]
+}
+
+/**
+ * ProfileConfigControl
+ */
+export interface ProfileConfigControl {
+  code: string
+  name: string
+  description: string
+}
+
+/**
+ * ProfileConfigIdentity
+ */
+export interface ProfileConfigIdentity {
+  space: string
+  isProfile: boolean
+}
+
+/**
  * ProfileConfiguration
  */
 export interface ProfileConfiguration {
   attributes?: ProfileAttribute[]
+  collections?: ProfileCollection[]
+  identities?: Record<string, ProfileConfigIdentity>
+  topics?: ProfileConfigTopic[]
+  controls?: ProfileConfigControl[]
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3431,21 +3431,21 @@ export interface ProfilePreferencesContext {
 /**
  * CollectionSubscriptionTopicSetting
  */
-export type CollectionSubscriptionTopicSetting = Record<string, { status: 'granted' | 'denied' }>
+export type CollectionSubscriptionTopicSetting = { [key: string]: { status: SubscriptionStatus } }
 
 /**
  * CollectionSubscriptionControlSetting
  */
 export interface CollectionSubscriptionControlSetting {
-  status: 'granted' | 'denied'
+  status: SubscriptionStatus
 }
 
 /**
  * CollectionSubscriptions
  */
 export interface CollectionSubscriptions {
-  topics?: Record<string, CollectionSubscriptionTopicSetting>
-  controls?: Record<string, CollectionSubscriptionControlSetting>
+  topics?: { [key: string]: CollectionSubscriptionTopicSetting }
+  controls?: { [key: string]: CollectionSubscriptionControlSetting }
 }
 
 /**
@@ -3566,7 +3566,7 @@ export interface CollectionSection {
   code: string
   name: string
   displayName: string
-  displayNameTranslations?: Record<string, string>
+  displayNameTranslations?: { [key: string]: string }
   items: CollectionItem[]
   order: number
 }
@@ -3578,9 +3578,9 @@ export interface Collection {
   code: string
   name: string
   displayName: string
-  displayNameTranslations?: Record<string, string>
+  displayNameTranslations?: { [key: string]: string }
   description?: string
-  descriptionTranslations?: Record<string, string>
+  descriptionTranslations?: { [key: string]: string }
   sections: CollectionSection[]
 }
 
@@ -3617,7 +3617,7 @@ export interface ProfileConfigIdentity {
 export interface ProfileConfiguration {
   attributes?: ProfileAttribute[]
   collections?: Collection[]
-  identities?: Record<string, ProfileConfigIdentity>
+  identities?: { [key: string]: ProfileConfigIdentity }
   topics?: ProfileConfigTopic[]
   controls?: ProfileConfigControl[]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3429,23 +3429,23 @@ export interface ProfilePreferencesContext {
 }
 
 /**
- * ProfileSubscriptionTopicSetting
+ * CollectionSubscriptionTopicSetting
  */
-export type ProfileSubscriptionTopicSetting = Record<string, { status: 'granted' | 'denied' }>
+export type CollectionSubscriptionTopicSetting = Record<string, { status: 'granted' | 'denied' }>
 
 /**
- * ProfileSubscriptionControlSetting
+ * CollectionSubscriptionControlSetting
  */
-export interface ProfileSubscriptionControlSetting {
+export interface CollectionSubscriptionControlSetting {
   status: 'granted' | 'denied'
 }
 
 /**
- * ProfileSubscriptions
+ * CollectionSubscriptions
  */
-export interface ProfileSubscriptions {
-  topics?: Record<string, ProfileSubscriptionTopicSetting>
-  controls?: Record<string, ProfileSubscriptionControlSetting>
+export interface CollectionSubscriptions {
+  topics?: Record<string, CollectionSubscriptionTopicSetting>
+  controls?: Record<string, CollectionSubscriptionControlSetting>
 }
 
 /**
@@ -3460,7 +3460,7 @@ export interface PutProfileRequest {
   languageCode: string
   identities: ProfilePreferencesIdentity[]
   attributes?: ProfilePreferencesAttribute[]
-  subscriptions?: ProfileSubscriptions
+  subscriptions?: CollectionSubscriptions
   context: ProfilePreferencesContext
   accountId?: string
   regionCode?: string
@@ -3491,7 +3491,7 @@ export interface GetProfileResponse {
   jurisdictionCode?: string
   regionCode?: string
   attributes?: ProfilePreferencesAttribute[]
-  subscriptions?: ProfileSubscriptions
+  subscriptions?: CollectionSubscriptions
 }
 
 /**
@@ -6288,7 +6288,7 @@ export interface Profile {
   consent: ProfileConsentSection
   identities?: ProfileIdentitySection
   user?: ProfileUserSection
-  subscription?: ProfileSubscriptionSection
+  subscription?: CollectionSubscriptionSection
   profilePreferences?: ProfilePreferencesSection
   metadata?: ProfileMetadataSection
   page?: ProfilePageSection
@@ -6309,7 +6309,7 @@ export interface ProfileUserSection {
   [userAttributeCode: string]: { value: any }
 }
 
-export interface ProfileSubscriptionSection {
+export interface CollectionSubscriptionSection {
   topics?: { [topicCode: string]: SubscriptionTopicSetting }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3545,43 +3545,43 @@ export interface ProfileAttribute {
 }
 
 /**
- * ProfileCollectionItemType
+ * CollectionItemType
  */
-export type ProfileCollectionItemType = 'attribute' | 'subscription_topic' | 'subscription_control'
+export type CollectionItemType = 'attribute' | 'subscription_topic' | 'subscription_control'
 
 /**
- * ProfileCollectionItem
+ * CollectionItem
  */
-export interface ProfileCollectionItem {
-  type: ProfileCollectionItemType
+export interface CollectionItem {
+  type: CollectionItemType
   code: string
   id?: string
   order: number
 }
 
 /**
- * ProfileCollectionSection
+ * CollectionSection
  */
-export interface ProfileCollectionSection {
+export interface CollectionSection {
   code: string
   name: string
   displayName: string
   displayNameTranslations?: Record<string, string>
-  items: ProfileCollectionItem[]
+  items: CollectionItem[]
   order: number
 }
 
 /**
- * ProfileCollection
+ * Collection
  */
-export interface ProfileCollection {
+export interface Collection {
   code: string
   name: string
   displayName: string
   displayNameTranslations?: Record<string, string>
   description?: string
   descriptionTranslations?: Record<string, string>
-  sections: ProfileCollectionSection[]
+  sections: CollectionSection[]
 }
 
 /**
@@ -3616,7 +3616,7 @@ export interface ProfileConfigIdentity {
  */
 export interface ProfileConfiguration {
   attributes?: ProfileAttribute[]
-  collections?: ProfileCollection[]
+  collections?: Collection[]
   identities?: Record<string, ProfileConfigIdentity>
   topics?: ProfileConfigTopic[]
   controls?: ProfileConfigControl[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3429,23 +3429,23 @@ export interface ProfilePreferencesContext {
 }
 
 /**
- * CollectionSubscriptionTopicSetting
+ * ProfileSubscriptionTopicSetting
  */
-export type CollectionSubscriptionTopicSetting = { [key: string]: { status: SubscriptionStatus } }
+export type ProfileSubscriptionTopicSetting = { [key: string]: { status: SubscriptionStatus } }
 
 /**
- * CollectionSubscriptionControlSetting
+ * ProfileSubscriptionControlSetting
  */
-export interface CollectionSubscriptionControlSetting {
+export interface ProfileSubscriptionControlSetting {
   status: SubscriptionStatus
 }
 
 /**
- * CollectionSubscriptions
+ * ProfileSubscriptions
  */
-export interface CollectionSubscriptions {
-  topics?: { [key: string]: CollectionSubscriptionTopicSetting }
-  controls?: { [key: string]: CollectionSubscriptionControlSetting }
+export interface ProfileSubscriptions {
+  topics?: { [key: string]: ProfileSubscriptionTopicSetting }
+  controls?: { [key: string]: ProfileSubscriptionControlSetting }
 }
 
 /**
@@ -3460,7 +3460,7 @@ export interface PutProfileRequest {
   languageCode: string
   identities: ProfilePreferencesIdentity[]
   attributes?: ProfilePreferencesAttribute[]
-  subscriptions?: CollectionSubscriptions
+  subscriptions?: ProfileSubscriptions
   context: ProfilePreferencesContext
   accountId?: string
   regionCode?: string
@@ -3491,7 +3491,7 @@ export interface GetProfileResponse {
   jurisdictionCode?: string
   regionCode?: string
   attributes?: ProfilePreferencesAttribute[]
-  subscriptions?: CollectionSubscriptions
+  subscriptions?: ProfileSubscriptions
 }
 
 /**
@@ -3545,43 +3545,43 @@ export interface ProfileAttribute {
 }
 
 /**
- * CollectionItemType
+ * ProfileCollectionItemType
  */
-export type CollectionItemType = 'attribute' | 'subscription_topic' | 'subscription_control'
+export type ProfileCollectionItemType = 'attribute' | 'subscription_topic' | 'subscription_control'
 
 /**
- * CollectionItem
+ * ProfileCollectionItem
  */
-export interface CollectionItem {
-  type: CollectionItemType
+export interface ProfileCollectionItem {
+  type: ProfileCollectionItemType
   code: string
   id?: string
   order: number
 }
 
 /**
- * CollectionSection
+ * ProfileCollectionSection
  */
-export interface CollectionSection {
+export interface ProfileCollectionSection {
   code: string
   name: string
   displayName: string
   displayNameTranslations?: { [key: string]: string }
-  items: CollectionItem[]
+  items: ProfileCollectionItem[]
   order: number
 }
 
 /**
- * Collection
+ * ProfileCollection
  */
-export interface Collection {
+export interface ProfileCollection {
   code: string
   name: string
   displayName: string
   displayNameTranslations?: { [key: string]: string }
   description?: string
   descriptionTranslations?: { [key: string]: string }
-  sections: CollectionSection[]
+  sections: ProfileCollectionSection[]
 }
 
 /**
@@ -3616,7 +3616,7 @@ export interface ProfileConfigIdentity {
  */
 export interface ProfileConfiguration {
   attributes?: ProfileAttribute[]
-  collections?: Collection[]
+  collections?: ProfileCollection[]
   identities?: { [key: string]: ProfileConfigIdentity }
   topics?: ProfileConfigTopic[]
   controls?: ProfileConfigControl[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -6288,7 +6288,7 @@ export interface Profile {
   consent: ProfileConsentSection
   identities?: ProfileIdentitySection
   user?: ProfileUserSection
-  subscription?: CollectionSubscriptionSection
+  subscription?: ProfileSubscriptionSection
   profilePreferences?: ProfilePreferencesSection
   metadata?: ProfileMetadataSection
   page?: ProfilePageSection
@@ -6309,7 +6309,7 @@ export interface ProfileUserSection {
   [userAttributeCode: string]: { value: any }
 }
 
-export interface CollectionSubscriptionSection {
+export interface ProfileSubscriptionSection {
   topics?: { [topicCode: string]: SubscriptionTopicSetting }
 }
 


### PR DESCRIPTION
## Description of this change

Add TypeScript types for the unified profile + subscriptions feature:

- `ProfileCollection`, `ProfileCollectionSection`, `ProfileCollectionItem` with `ProfileCollectionItemType` enum
- `ProfileConfigTopic`, `ProfileConfigControl`, `ProfileConfigIdentity` for config metadata
- `ProfileSubscriptions`, `ProfileSubscriptionTopicSetting`, `ProfileSubscriptionControlSetting` for subscription state
- Updated `ProfileConfiguration` with `collections`, `identities`, `topics`, `controls`
- Updated `GetProfileRequest`/`PutProfileRequest` with `controllerCode`
- Updated `GetProfileResponse` with `controllerCode`, `environmentCode`, `jurisdictionCode`, `subscriptions`
- Updated `PutProfileRequest` with `subscriptions`

This is part of the profile + subscriptions unification effort. Companion PRs in supercargo (collection schema + config) and wheelhouse (profile API).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

- `npx tsc --noEmit` passes with no errors

## Related issues

Part of profile + subscriptions unification. Companion PRs in `supercargo` and `wheelhouse`.

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

Made with [Cursor](https://cursor.com)