### PR TITLE
feat(types): add cachedAt to GetConsentResponse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2781,6 +2781,8 @@ export interface GetConsentResponse {
   googleVendors?: string[]
 
   collectedAt?: number
+  // Client-only: unix seconds when consent was last read from GET.
+  cachedAt?: number
   protocols?: Protocols
   vendorConsents?: VendorConsents
   showAfter?: number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Adds optional `cachedAt` on `GetConsentResponse` so ketch-tag can stamp when consent was last read

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Type-only change; `npm run format` applied locally.

## Related issues
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
