### PR TITLE
feat: [KD-16962] add ExperienceTopicsConfig to experience config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5794,11 +5794,21 @@ export enum ExperiencePurposeMode {
   INHERIT = 'INHERIT',
 }
 
+export enum ExperienceTopicMode {
+  CUSTOM = 'CUSTOM',
+  INHERIT = 'INHERIT',
+}
+
 export interface ExperiencePurposesConfig {
   mode?: ExperiencePurposeMode
   purposeIDs?: string[]
   stackIDs?: string[]
   order?: ExperiencePurposesOrStacksConfig[]
+}
+
+export interface ExperienceTopicsConfig {
+  mode?: ExperienceTopicMode
+  topicCodes?: string[]
 }
 
 export enum PurposeOrStackType {
@@ -5816,6 +5826,7 @@ export interface ExperienceConfig {
   content?: ExperienceContentConfig
   associations?: ExperienceAssociationConfig
   purposes?: ExperiencePurposesConfig
+  topics?: ExperienceTopicsConfig
 }
 
 /**


### PR DESCRIPTION
## Description
> - Add `ExperienceTopicMode` enum (CUSTOM/INHERIT)
> - Add `ExperienceTopicsConfig` interface and an optional `topics` field on `ExperienceConfig`

ticket: https://ketch-com.atlassian.net/browse/KD-16962

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
Type-only change; mirrors the existing `ExperiencePurposesConfig` / `ExperiencePurposeMode` pattern. Consumed by the KD-16962 experience topics work in figurehead and supercargo.

## Related issues
ketch-types: https://github.com/ketch-sdk/ketch-types/pull/354
figurehead: https://github.com/ketch-com/figurehead/pull/5900
supercargo: https://github.com/ketch-com/supercargo/pull/2659

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
