### PR TITLE
feat: add experience topics config types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5787,11 +5787,33 @@ export interface ExperiencePurposesOrStacksConfig {
   id: string
 }
 
+export enum ExperienceTopicMode {
+  CUSTOM = 'CUSTOM',
+  INHERIT = 'INHERIT',
+}
+
+export enum TopicOrStackType {
+  TOPIC = 'TOPIC',
+  STACK = 'STACK',
+}
+
+export interface ExperienceTopicsOrStacksConfig {
+  type: TopicOrStackType
+  code: string
+}
+
+export interface ExperienceTopicsConfig {
+  mode?: ExperienceTopicMode
+  topicCodes?: string[]
+  order?: ExperienceTopicsOrStacksConfig[]
+}
+
 export interface ExperienceConfig {
   layout?: ExperienceLayoutConfig
   content?: ExperienceContentConfig
   associations?: ExperienceAssociationConfig
   purposes?: ExperiencePurposesConfig
+  topics?: ExperienceTopicsConfig
 }
 
 /**


### PR DESCRIPTION
## Description of this change
> - Add `ExperienceTopicsConfig` (`mode`, `topicCodes`, `order`) and supporting types (`ExperienceTopicMode`, `TopicOrStackType`, `ExperienceTopicsOrStacksConfig`)
> - Add `topics?: ExperienceTopicsConfig` to `ExperienceConfig`
> - Mirrors the existing `ExperiencePurposesConfig` pattern; matches the `topics` block supercargo emits per experience since ketch-com/supercargo#2665 (subscription topics v2 / PD-339)

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
`npm run build` and `npm run lint` pass. Additive types only; verified the shape against the config JSON emitted by supercargo's `GetConfigExperiences`/`GetPreviewConfiguration` (mode INHERIT/CUSTOM, topicCodes, order entries of `{type: TOPIC|STACK, code}`).

## Related issues
ketch-com/supercargo#2665

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
