### PR TITLE
feat: add legitimate interest layout and content config types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4567,6 +4567,17 @@ export enum SwitchButtonDisplay {
   WhenLegalBasisDiffers = 'whenLegalBasisDiffers',
 }
 
+export enum LegitimateInterestSwitchButtonLabelDisplay {
+  SwitchButton = 'switchButton',
+  Checkbox = 'checkbox',
+  ActionButton = 'actionButton',
+}
+
+export interface LegitimateInterestSwitchButtonLabelLayoutConfig {
+  display?: LegitimateInterestSwitchButtonLabelDisplay
+  useDefaultText?: boolean
+}
+
 export interface SwitchButtonsExperienceLayoutConfig {
   visible?: boolean
   display?: SwitchButtonDisplay
@@ -4761,6 +4772,9 @@ export interface ModalPurposeListExperienceLayoutConfig {
   purposes?: (PurposeExperienceLayoutConfig | PurposeStackExperienceLayoutConfig)[]
   gpcSignal?: GpcSignalExperienceLayoutConfig
   attSignal?: AttSignalExperienceLayoutConfig
+  consentSwitchButtonLabel?: SwitchButtonsExperienceLayoutConfig
+  legitimateInterestSwitchButtonLabel?: LegitimateInterestSwitchButtonLabelLayoutConfig
+  legitimateInterestStatusSwitchLabels?: SwitchButtonsExperienceLayoutConfig
 }
 
 /**
@@ -4873,6 +4887,9 @@ export interface PurposesTabListExperienceLayoutConfig {
   purposes?: (PurposeExperienceLayoutConfig | PurposeStackExperienceLayoutConfig)[]
   gpcSignal?: GpcSignalExperienceLayoutConfig
   attSignal?: AttSignalExperienceLayoutConfig
+  consentSwitchButtonLabel?: SwitchButtonsExperienceLayoutConfig
+  legitimateInterestSwitchButtonLabel?: LegitimateInterestSwitchButtonLabelLayoutConfig
+  legitimateInterestStatusSwitchLabels?: SwitchButtonsExperienceLayoutConfig
 }
 
 /**
@@ -5255,6 +5272,9 @@ export interface ModalPurposeListExperienceContentConfig {
   vendors?: VendorExperienceSubpageContentConfig
   gpcSignal?: GpcSignalExperienceContentConfig
   attSignal?: AttSignalExperienceContentConfig
+  consentSwitchButtonLabel?: { labelText?: string }
+  legitimateInterestSwitchButtonLabel?: { labelText?: string }
+  legitimateInterestStatusSwitchLabels?: SwitchButtonsExperienceContentConfig
 }
 
 /**
@@ -5351,6 +5371,9 @@ export interface PurposesTabListExperienceContentConfig {
   vendors?: VendorExperienceSubpageContentConfig
   gpcSignal?: GpcSignalExperienceContentConfig
   attSignal?: AttSignalExperienceContentConfig
+  consentSwitchButtonLabel?: { labelText?: string }
+  legitimateInterestSwitchButtonLabel?: { labelText?: string }
+  legitimateInterestStatusSwitchLabels?: SwitchButtonsExperienceContentConfig
 }
 
 /**


### PR DESCRIPTION
## Description of this change

> Adds TypeScript types for the Legitimate Interest (LI) controls feature in the experience builder.
>
> - Add `LegitimateInterestSwitchButtonLabelDisplay` enum with `switchButton`, `checkbox`, and `actionButton` values
> - Add `LegitimateInterestSwitchButtonLabelLayoutConfig` interface for LI display mode layout config
> - Add `consentSwitchButtonLabel`, `legitimateInterestSwitchButtonLabel`, and `legitimateInterestStatusSwitchLabels` fields to `ModalPurposeListExperienceLayoutConfig` and `PurposesTabListExperienceLayoutConfig`
> - Add same three fields to `ModalPurposeListExperienceContentConfig` and `PurposesTabListExperienceContentConfig`



## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - `npm run build` passes cleanly with zero TypeScript errors
> - All new types verified against figurehead experience builder usage

## Related issues

[KD-17067](https://ketch-com.atlassian.net/browse/KD-17067)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

[KD-17067]: https://ketch-com.atlassian.net/browse/KD-17067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ