### PR TITLE
feat: rename showLegitimateInterest to allowsLegitimateInterest on Purpose

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -861,7 +861,7 @@ export interface Purpose {
   canonicalPurposeCodes?: string[]
 
   ageBands?: AgeBand[]
-  showLegitimateInterest?: boolean
+  allowsLegitimateInterest?: boolean
 }
 
 /**


### PR DESCRIPTION
## Description of this change

> Renames the `showLegitimateInterest` field on the `Purpose` interface to `allowsLegitimateInterest` to match the field name returned by the backend API.
>
> - Renamed `showLegitimateInterest` → `allowsLegitimateInterest` on the `Purpose` interface in `src/index.ts`



## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Confirmed `allowsLegitimateInterest` is the field name returned by the backend API in the purposes config
> - Built the package — `dist/index.d.ts` updated correctly
> - Verified no existing consumers of `showLegitimateInterest` across lanyard, semaphore, or figurehead

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.