### PR TITLE
feat: add non_objectable and not_objected to BaseStaticContentConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5743,6 +5743,8 @@ export interface BaseStaticContentConfig {
   marketing?: string
   maximum_storage?: string
   no_rights_available?: string
+  non_objectable?: string
+  not_objected?: string
   object_to_legitimate_interest?: string
   of?: string
   off?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -2128,6 +2128,9 @@ export interface Translations {
   ex_i_worked_in_the_it_department_in_2015?: string
   opted_in?: string
   opted_out?: string
+  object_to_legitimate_interest?: string
+  non_objectable?: string
+  not_objected?: string
   rights_tab_porthole_redirect_footer?: string
   rights_tab_porthole_redirect_footer_alt?: string
   click_here?: string


### PR DESCRIPTION
## Description of this change

> Adds two missing LI status translation keys to `BaseStaticContentConfig`.
>
> - Add `non_objectable` key for the non-objectable/disabled LI state
> - Add `not_objected` key for the established/not-yet-objected LI state

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Type-only change, no runtime behavior changed
> - Keys are optional and follow the same pattern as existing keys (`object_to_legitimate_interest`, `opted_in`, `opted_out`)
> - Alphabetically ordered within the interface

## Related issues

Part of LI controls feature — lanyard will consume these keys in a follow-up to replace hardcoded English strings.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.