### PR TITLE
feat: add consent and legitimate_interest label keys to static translations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2126,6 +2126,8 @@ export interface Translations {
   select_a_relationship?: string
   tell_us_about_your_relationship_to_us?: string
   ex_i_worked_in_the_it_department_in_2015?: string
+  consent?: string
+  legitimate_interest?: string
   opted_in?: string
   opted_out?: string
   object_to_legitimate_interest?: string
@@ -5719,6 +5721,7 @@ export interface BaseStaticContentConfig {
   category?: string
   click_here?: string
   cookie?: string
+  consent?: string
   cookies?: string
   data_categories?: string
   data_category?: string
@@ -5736,6 +5739,7 @@ export interface BaseStaticContentConfig {
   i_am_a_an?: string
   legal_basis?: string
   legal_text?: string
+  legitimate_interest?: string
   gpc_banner_title?: string
   gpc_banner_description?: string
   gpc_signal_label?: string


### PR DESCRIPTION
## Description of this change

> Adds missing label translation keys for consent and legitimate interest to `BaseStaticContentConfig` and `Translations`.
>
> - Add `consent` key for the Consent switch label
> - Add `legitimate_interest` key for the Legitimate Interest switch label

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Type-only change, no runtime behavior changed
> - Keys are optional and follow the same pattern as existing keys
> - Alphabetically ordered within the interface

## Related issues

Follow-up to LI controls feature — lanyard will consume these keys to replace hardcoded English label strings.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.