### PR TITLE
feat: add objected translation key to StaticContentConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2133,6 +2133,7 @@ export interface Translations {
   object_to_legitimate_interest?: string
   non_objectable?: string
   not_objected?: string
+  objected?: string
   rights_tab_porthole_redirect_footer?: string
   rights_tab_porthole_redirect_footer_alt?: string
   click_here?: string
@@ -5753,6 +5754,7 @@ export interface BaseStaticContentConfig {
   non_objectable?: string
   not_objected?: string
   object_to_legitimate_interest?: string
+  objected?: string
   of?: string
   off?: string
   on?: string


### PR DESCRIPTION
## Description of this change

> Adds `objected` translation key to `StaticContentConfig` and `BaseStaticContentConfig`.
>
> - Added `objected?: string` to both `StaticContentConfig` interfaces in `index.ts`

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Consumed in lanyard to replace hardcoded "Objected" suffix in LI ActionButton display mode

## Related issues

Part of legitimate interest UI controls feature.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.