### PR TITLE
feat: add legitimate_interest_objected and legitimate_interest_non_objectable translation keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2128,6 +2128,8 @@ export interface Translations {
   ex_i_worked_in_the_it_department_in_2015?: string
   consent?: string
   legitimate_interest?: string
+  legitimate_interest_objected?: string
+  legitimate_interest_non_objectable?: string
   opted_in?: string
   opted_out?: string
   object_to_legitimate_interest?: string
@@ -5741,6 +5743,8 @@ export interface BaseStaticContentConfig {
   legal_basis?: string
   legal_text?: string
   legitimate_interest?: string
+  legitimate_interest_objected?: string
+  legitimate_interest_non_objectable?: string
   gpc_banner_title?: string
   gpc_banner_description?: string
   gpc_signal_label?: string


### PR DESCRIPTION
## Description of this change

> Adds two new static translation keys to support Action Button display mode for LI controls.
>
> - Add `legitimate_interest_objected` to `Translations` and `BaseStaticContentConfig`
> - Add `legitimate_interest_non_objectable` to `Translations` and `BaseStaticContentConfig`

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Types compile cleanly
> - Keys consumed by lanyard Action Button LI control fix

## Related issues

Part of LI Action Button display mode fix

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.