### PR TITLE
fix: LI type gaps in SetConsentResponse and named types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -481,6 +481,10 @@ export enum LegitimateInterestStatus {
   OBJECTED = 'objected',
 }
 
+export type PurposeLegitimateInterests = { [key: string]: LegitimateInterestStatus }
+export type VendorLegitimateInterest = { [key: string]: LegitimateInterestStatus }
+export type VendorLegitimateInterests = { [key: string]: VendorLegitimateInterest }
+
 /**
  * Consent
  */
@@ -502,8 +506,8 @@ export type Consent = {
   isGpcEnabled?: boolean
   isAttActive?: boolean
   vendorConsents?: VendorConsents
-  purposeLegitimateInterests?: { [key: string]: LegitimateInterestStatus }
-  vendorLegitimateInterests?: { [key: string]: { [key: string]: LegitimateInterestStatus } }
+  purposeLegitimateInterests?: PurposeLegitimateInterests
+  vendorLegitimateInterests?: VendorLegitimateInterests
 }
 
 /**
@@ -2810,8 +2814,8 @@ export interface GetConsentResponse {
   // Was this consent set interactively
   interactive?: boolean
 
-  purposeLegitimateInterests?: { [key: string]: LegitimateInterestStatus }
-  vendorLegitimateInterests?: { [key: string]: { [key: string]: LegitimateInterestStatus } }
+  purposeLegitimateInterests?: PurposeLegitimateInterests
+  vendorLegitimateInterests?: VendorLegitimateInterests
 }
 
 /**
@@ -2846,8 +2850,8 @@ export interface SetConsentRequest {
   // Was this consent set interactively
   interactive?: boolean
 
-  purposeLegitimateInterests?: { [key: string]: LegitimateInterestStatus }
-  vendorLegitimateInterests?: { [key: string]: { [key: string]: LegitimateInterestStatus } }
+  purposeLegitimateInterests?: PurposeLegitimateInterests
+  vendorLegitimateInterests?: VendorLegitimateInterests
 }
 
 /**
@@ -2877,8 +2881,8 @@ export interface SetConsentResponse {
   collectedAt?: number
   protocols?: Protocols
   vendorConsents?: VendorConsents
-  purposeLegitimateInterests?: { [key: string]: LegitimateInterestStatus }
-  vendorLegitimateInterests?: { [key: string]: { [key: string]: LegitimateInterestStatus } }
+  purposeLegitimateInterests?: PurposeLegitimateInterests
+  vendorLegitimateInterests?: VendorLegitimateInterests
   context?: PermitRightContext
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2877,6 +2877,8 @@ export interface SetConsentResponse {
   collectedAt?: number
   protocols?: Protocols
   vendorConsents?: VendorConsents
+  purposeLegitimateInterests?: { [key: string]: LegitimateInterestStatus }
+  vendorLegitimateInterests?: { [key: string]: { [key: string]: LegitimateInterestStatus } }
   context?: PermitRightContext
 }
 


### PR DESCRIPTION
## Description of this change

> Closes type gaps in SetConsentResponse and introduces named types for legitimate interest fields to match the existing VendorConsent/VendorConsents pattern.
>
> - Adds purposeLegitimateInterests and vendorLegitimateInterests to SetConsentResponse (were missing despite being in SetConsentRequest and GetConsentResponse)
> - Introduces three named types after LegitimateInterestStatus: PurposeLegitimateInterests, VendorLegitimateInterest, VendorLegitimateInterests
> - Replaces inline { [key: string]: LegitimateInterestStatus } types across all 4 interfaces (Consent, GetConsentResponse, SetConsentRequest, SetConsentResponse) with the new named types
> - No functional or behavioral change — TypeScript structural typing makes named aliases fully transparent to consuming code

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Confirmed PUT /consent response includes both fields in live API testing
> - Confirmed named types are structurally identical to the inline types they replace
> - Verified no existing consuming code in lanyard or ketch-tag is affected
> - Two independent engineer reviews confirmed zero breaking changes

## Related issues

n/a

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

[PD-354]: https://ketch-com.atlassian.net/browse/PD-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ