### PR TITLE
feat: add checkbox and actionButton to PurposeListThemeConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3857,12 +3857,7 @@ export interface SwitchButtonsThemeConfig {
  * Purpose List Theme Configuration
  */
 
-/**
- * Distinct from ActionButtonThemeConfig, which is single-state (e.g. acceptAllButton,
- * rejectAllButton) — the purpose list action button (legitimate interest control) needs
- * separate selected/unselected states, so it gets its own type rather than reshaping the
- * single-state one and breaking its other consumers.
- */
+/** Separate from ActionButtonThemeConfig (single-state) since this needs selected/unselected states. */
 export interface PurposeListActionButtonStateThemeConfig {
   background?: ColorThemeConfig
   outline?: ColorThemeConfig

--- a/src/index.ts
+++ b/src/index.ts
@@ -3857,9 +3857,33 @@ export interface SwitchButtonsThemeConfig {
  * Purpose List Theme Configuration
  */
 
+/**
+ * Distinct from ActionButtonThemeConfig, which is single-state (e.g. acceptAllButton,
+ * rejectAllButton) — the purpose list action button (legitimate interest control) needs
+ * separate selected/unselected states, so it gets its own type rather than reshaping the
+ * single-state one and breaking its other consumers.
+ */
+export interface PurposeListActionButtonStateThemeConfig {
+  background?: ColorThemeConfig
+  outline?: ColorThemeConfig
+  text?: TextThemeConfig
+}
+
+export interface PurposeListActionButtonThemeConfig {
+  selected?: PurposeListActionButtonStateThemeConfig
+  unselected?: PurposeListActionButtonStateThemeConfig
+  iconVisible?: boolean
+  useDefaultIcon?: boolean
+  iconColor?: ColorThemeConfig
+  iconUrl?: string
+  cornerRadius?: number
+}
+
 export interface PurposeListThemeConfig {
   purposeListItems?: ListItemsThemeConfig
   switchButtons?: SwitchButtonsThemeConfig
+  checkbox?: CheckboxesThemeConfig
+  actionButton?: PurposeListActionButtonThemeConfig
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `checkbox?: CheckboxesThemeConfig` to `PurposeListThemeConfig` (reuses the existing `CheckboxesThemeConfig`/`CheckboxThemeConfig` as-is)
- Add `actionButton?: PurposeListActionButtonThemeConfig` (new type) to `PurposeListThemeConfig`, supporting `selected`/`unselected` states plus `iconVisible`/`useDefaultIcon`/`iconColor`/`iconUrl`/`cornerRadius`
- These back a "Purposes List Controls" theming feature (Switch/Checkbox/Action Button display modes for the Legitimate Interest control) already built and verified against local type augmentations in figurehead and lanyard
- Kept `actionButton` as its own new type rather than reshaping the existing single-state `ActionButtonThemeConfig` (used by `acceptAllButton`/`rejectAllButton`/banner buttons), since that would be a breaking change for its other consumers

## Test plan
- [x] `npm run build` compiles clean
- [x] `npm run test` passes (100% coverage maintained)
- [x] `npm run format-check` passes
- [x] Verified every field this type exposes is actually read/written by figurehead and lanyard's local type augmentations (no gaps, no unused fields beyond what's already optional-by-convention)
- [ ] Bump `@ketch-sdk/ketch-types` in figurehead and lanyard, delete their local `ketch-types-controls-augmentation.d.ts`, and confirm typecheck passes against the real published types