### PR TITLE
feat: [KD-17927] profile descriptions + item required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3582,6 +3582,9 @@ export interface SubscriptionConfiguration {
 export interface ProfileAttributeValue {
   value: string
   label?: string
+  labelTranslations?: { [key: string]: string }
+  description?: string
+  descriptionTranslations?: { [key: string]: string }
   sortOrder?: number
 }
 
@@ -3628,6 +3631,7 @@ export interface ProfileCollectionItem {
   code: string
   id?: string
   order: number
+  required?: boolean
 }
 
 /**
@@ -3638,6 +3642,8 @@ export interface ProfileCollectionSection {
   name: string
   displayName: string
   displayNameTranslations?: { [key: string]: string }
+  description?: string
+  descriptionTranslations?: { [key: string]: string }
   items: ProfileCollectionItem[]
   order: number
 }


### PR DESCRIPTION
## Description
> - ProfileCollectionSection: add description + descriptionTranslations (supercargo already serves them)
> - ProfileAttributeValue: add description, labelTranslations, descriptionTranslations
> - ProfileCollectionItem: add required (serialized by the supercargo KD-17927 change)

ticket: https://ketch-com.atlassian.net/browse/KD-17927

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
Additive optional fields only; `tsc -p . --noEmit` passes. Field names verified against the exact JSON tags supercargo serves (entity3 config structs + MapProfileAttributeValues output).

## Related issues
https://ketch-com.atlassian.net/browse/KD-17927

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
