### PR TITLE
feat(types): Add DST scoping and multi-jurisdiction rights fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1328,11 +1328,11 @@ export interface Right {
   name: string
   description: string
 
-  /**
-   * the data subject types for which the right is relevant. If this list is empty then the right applies to all
-   * data subject types
-   */
+  // the data subject types for which the right is relevant
   dataSubjectTypeCodes?: string[]
+  //scoped: true means only the data subject types in dataSubjectTypeCodes may exercise this right; false/undefined (default) means all may.
+  scoped?: boolean
+  
   canonicalRightCode: string
 }
 
@@ -1516,6 +1516,11 @@ export interface DataSubjectType {
    * requiresUserInput is true if additional information must be requested to describe the data subject relation
    */
   requiresUserInput: boolean
+
+  /**
+   * userInputLabel is the resolved label for the additional-information field; empty uses the client default.
+   */
+  userInputLabel?: string
 }
 
 /**
@@ -1556,6 +1561,12 @@ export interface ConfigurationV2 {
    * Unique identifier for this configuration object
    */
   id?: string
+
+  /**
+   * Rights for each of the organization's jurisdictions, keyed by jurisdiction code (e.g.
+   * "US_California"); additive alongside `rights`, which stays the resolved jurisdiction's rights.
+   */
+  rightsByJurisdiction?: { [jurisdiction: string]: Right[] }
 
   /**
    * Organization this configuration belongs to

--- a/src/index.ts
+++ b/src/index.ts
@@ -1116,6 +1116,15 @@ export interface JIT {
 }
 
 /**
+ * Selects what the runtime Data Subject Details block renders; undefined is treated as
+ * LOCATION_AND_SUBJECT_TYPE.
+ */
+export enum DataSubjectDetailsMode {
+  LOCATION_AND_SUBJECT_TYPE = 'locationAndSubjectType',
+  SUBJECT_TYPE_ONLY = 'subjectTypeOnly',
+}
+
+/**
  * RightsTab
  */
 export interface RightsTab {
@@ -1152,6 +1161,8 @@ export interface RightsTab {
    * Recaptcha Enabled
    */
   recaptchaEnabled?: boolean
+
+  dataSubjectDetailsMode?: DataSubjectDetailsMode
 }
 
 /**
@@ -1332,10 +1343,10 @@ export interface Right {
   // the data subject types for which the right is relevant
   dataSubjectTypeCodes?: string[]
   /**
-   * scoped: true means only the data subject types in dataSubjectTypeCodes may exercise this right;
+   * true means only the data subject types in dataSubjectTypeCodes may exercise this right;
    * false/undefined (default) means all may.
    */
-  scoped?: boolean
+  scopedBySubjectType?: boolean
 
   canonicalRightCode: string
 }
@@ -1525,6 +1536,11 @@ export interface DataSubjectType {
    * userInputLabel is the resolved label for the additional-information field; empty uses the client default.
    */
   userInputLabel?: string
+
+  /**
+   * Marks this data subject type as an authorized agent; AA-specific behaviors gate on this flag.
+   */
+  isAuthorizedAgent?: boolean
 }
 
 /**
@@ -1571,6 +1587,11 @@ export interface ConfigurationV2 {
    * "US_California"); additive alongside `rights`, which stays the resolved jurisdiction's rights.
    */
   rightsByJurisdiction?: { [jurisdiction: string]: Right[] }
+
+  /**
+   * True iff any right in any jurisdiction is scoped by subject type.
+   */
+  hasSubjectTypeScopedRights?: boolean
 
   /**
    * Organization this configuration belongs to

--- a/src/index.ts
+++ b/src/index.ts
@@ -1331,7 +1331,10 @@ export interface Right {
 
   // the data subject types for which the right is relevant
   dataSubjectTypeCodes?: string[]
-  //scoped: true means only the data subject types in dataSubjectTypeCodes may exercise this right; false/undefined (default) means all may.
+  /**
+   * scoped: true means only the data subject types in dataSubjectTypeCodes may exercise this right;
+   * false/undefined (default) means all may.
+   */
   scoped?: boolean
   
   canonicalRightCode: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export enum ConsentExperienceType {
  * invokeRight = the right was invoked
  * close = the close/exit button was clicked
  * willNotShow = the experience was skipped
+ * setSubscriptions = the subscriptions were set
  *
  * @enum
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1336,7 +1336,7 @@ export interface Right {
    * false/undefined (default) means all may.
    */
   scoped?: boolean
-  
+
   canonicalRightCode: string
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Adds runtime-config TS types for jurisdiction + data-subject-type driven right rendering (KD-17644). `Right.scopedBySubjectType` and `ConfigurationV2.rightsByJurisdiction` (rights for each of the org's jurisdictions, keyed by jurisdiction code, additive alongside `rights`). `ConfigurationV2.hasSubjectTypeScopedRights` is a single flag so lanyard can gate the Data Subject Details block without scanning every right. `DataSubjectType.isAuthorizedAgent` (alongside the existing `userInputLabel`) lets authorized-agent behaviors gate on an explicit flag rather than code conventions. A new `DataSubjectDetailsMode` string enum (`'locationAndSubjectType'` | `'subjectTypeOnly'`) and `RightsTab.dataSubjectDetailsMode` field select which mode the runtime Data Subject Details block renders; undefined defaults to the fuller mode. Mirrors the corresponding additions to the supercargo proto contract in ketch-com/api. All fields are optional; backward compatible with existing `Configuration`/`ConfigurationV2` consumers (lanyard, ketch-tag), and `DataSubjectDetailsMode` is importable by figurehead the same way it already imports `ExperiencePurposeMode`/`PropertyPurposeMode`.
>
> **Companion PRs (land together):** [ketch-com/api#1092](https://github.com/ketch-com/api/pull/1092), [ketch-com/figurehead-gateway#1117](https://github.com/ketch-com/figurehead-gateway/pull/1117). All three implement the same KD-17644 contract additions and should be reviewed/merged together.

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run build` (`tsc -p .`) passes with no errors.

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Jira: https://ketch-com.atlassian.net/browse/KD-17644

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
