### PR TITLE
feat: [KD-17927] add profile tab theme config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4442,6 +4442,15 @@ export interface PreferenceRequestsTabThemeConfig {
 }
 
 /**
+ * Preference Center Profile Tab Theme Configuration
+ */
+
+export interface PreferenceProfileTabThemeConfig {
+  pageTitle?: TextThemeConfig
+  description?: TextThemeConfig
+}
+
+/**
  * Preference Center Tabs Theme Configuration
  */
 
@@ -4451,6 +4460,7 @@ export interface PreferenceTabsThemeConfig {
   purposes?: PreferencePurposesTabThemeConfig
   subscriptions?: PreferenceSubscriptionsTabThemeConfig
   requests?: PreferenceRequestsTabThemeConfig
+  profile?: PreferenceProfileTabThemeConfig
 }
 
 /**


### PR DESCRIPTION
## Description
> - Add `PreferenceProfileTabThemeConfig` (`pageTitle`, `description` as `TextThemeConfig`)
> - Add optional `profile?` field to `PreferenceTabsThemeConfig`
> - Enables independent theming of the preference-center Profile tab hero (page title + description), consumed by figurehead (theme editor) and lanyard (renderer)

ticket: https://ketch-com.atlassian.net/browse/KD-17927

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
- Types-only change; `npm run build` (tsc -p .) compiles clean
- Consumed by figurehead (Profile theme-editor controls) and lanyard (profile hero color reads) on their KD-17927 branches
- No UI in this repo, happy-path verification skipped

## Related issues
https://ketch-com.atlassian.net/browse/KD-17927

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Add screen recording
- [ ] I have evaluated the security impact of this change, and OWASP Secure Coding Practices have been observed.
- [ ] I have informed stakeholders of my changes.
