### PR TITLE
refactor(types): [KD-17644] replace dataSubjectDetailsMode enum with showLocation/showSubjectType bools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1116,15 +1116,6 @@ export interface JIT {
 }
 
 /**
- * Selects what the runtime Data Subject Details block renders; undefined is treated as
- * LOCATION_AND_SUBJECT_TYPE.
- */
-export enum DataSubjectDetailsMode {
-  LOCATION_AND_SUBJECT_TYPE = 'locationAndSubjectType',
-  SUBJECT_TYPE_ONLY = 'subjectTypeOnly',
-}
-
-/**
  * RightsTab
  */
 export interface RightsTab {
@@ -1162,7 +1153,8 @@ export interface RightsTab {
    */
   recaptchaEnabled?: boolean
 
-  dataSubjectDetailsMode?: DataSubjectDetailsMode
+  showLocation?: boolean
+  showSubjectType?: boolean
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Step 0.5 contract amendment for KD-17644. The `RightsTab.dataSubjectDetailsMode` enum (`LOCATION_AND_SUBJECT_TYPE` / `SUBJECT_TYPE_ONLY`) can't express every state the Data Subject Details block needs — location-only, subject-type-without-location, and the config-forced case where DST scoping turns the dropdown on regardless of the toggle. This replaces it with two independent booleans, `showLocation` and `showSubjectType`.
>
> The enum has zero consumers (no figurehead or lanyard reader), so this is a clean swap with no runtime migration. Contracts-only change — reader semantics, config-build stamping, and UI wiring are separate tracks.
>
> Companion PRs: api (`go.ketch.com/api`) and figurehead-gateway carry the matching proto/OpenAPI changes.

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run build` (`tsc -p .`) passes with no type errors. Confirmed `grep -rin "DataSubjectDetailsMode\|dataSubjectDetailsMode"` returns no hits in `src/`. No consumers exist yet, so nothing downstream to exercise.

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
KD-17644

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.