### PR TITLE
feat(types): [KD-17927] use PageTextThemeConfig for profile tab

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4438,8 +4438,7 @@ export interface PreferenceRequestsTabThemeConfig {
  */
 
 export interface PreferenceProfileTabThemeConfig {
-  pageTitle?: TextThemeConfig
-  description?: TextThemeConfig
+  header?: PageTextThemeConfig
 }
 
 /**


### PR DESCRIPTION
## Description
> - Reshape `PreferenceProfileTabThemeConfig` to use the shared `PageTextThemeConfig` (`header?` with title/description/link) instead of flat `pageTitle`/`description`
> - Aligns the profile tab with every other preference-center tab (welcome/subscriptions/requests all use `header?: PageTextThemeConfig`) and adds link theming for the profile hero
> - Replaces the flat fields added in 1.107; not consumed in prod (profile theming is flag-gated), so safe

ticket: https://ketch-com.atlassian.net/browse/KD-17927
figma: https://www.figma.com/design/vMdVjV1smWyjIibxrUtmlP/-PD-351--Profile--Phase-1----Preferences?node-id=27564-40592

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
Types-only package (no UI). `npm run build` (tsc) passes clean.

## Related issues
https://ketch-com.atlassian.net/browse/KD-17927

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Add screen recording
- [ ] I have evaluated the security impact of this change, and OWASP Secure Coding Practices have been observed.
- [ ] I have informed stakeholders of my changes.
