### PR TITLE
feat: add legitimateInterestVisible to VendorExperienceSubpageLayoutConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4708,6 +4708,7 @@ export interface VendorExperienceSubpageLayoutConfig {
   visible?: boolean
   includeOtherVendors?: boolean
   otherVendorIds?: string[] // System IDs
+  legitimateInterestVisible?: boolean
   link?: { useDefaultText?: boolean }
 }
 


### PR DESCRIPTION
## Description of this change

> Adds a new optional field to `VendorExperienceSubpageLayoutConfig` so orgs can control whether the vendor-level Legitimate Interest checkbox shows in Lanyard's consent UI, independent of the per-vendor GVL data check.
>
> - `legitimateInterestVisible?: boolean` added alongside the existing `visible`/`includeOtherVendors`/`otherVendorIds` fields
> - This is a shared type used by both Figurehead (writes the field via a new experience-builder toggle) and Lanyard (reads it, combined with a per-vendor GVL check, to decide whether to render the LI checkbox for a given vendor)
> - No backend changes involved — the field lives in supercargo's fully opaque `layout` JSON blob (`map[string]interface{}`), so this is purely a frontend type addition

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Ran `npm run build` (`tsc -p .`) — compiles clean
> - Confirmed this is a purely additive, optional field — non-breaking for any existing consumer

## Related issues

N/A

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.