### PR TITLE
feat: add optional experienceID to experienceClosed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3121,8 +3121,15 @@ export interface Ketch {
    * @param reason is a string representing the reason the experience was closed
    * @param consent is an optional object containing the consent state to set IF reason is setConsent
    * @param consentSource is an optional string representing the source of the consent
+   * @param experienceID is an optional id of the experience that was closed, used to track which of
+   * multiple concurrently-displayed experiences is being closed
    */
-  experienceClosed(reason: ExperienceClosedReason, consent?: Consent, consentSource?: ConsentSource): Promise<void>
+  experienceClosed(
+    reason: ExperienceClosedReason,
+    consent?: Consent,
+    consentSource?: ConsentSource,
+    experienceID?: string,
+  ): Promise<void>
 
   /**
    * Notify that the experience will be changed to a different format


### PR DESCRIPTION
## Description
> - Add optional `experienceID` param to `Ketch.experienceClosed()`
> - Lets consumers identify which of multiple concurrently-displayed experiences was closed

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
Type-only change. Verified `npx tsc --noEmit` compiles clean. `experienceID` is optional, so existing callers of `experienceClosed` remain source-compatible.

## Related issues
N/A

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
