### PR TITLE
feat(types): [KD-17644] add jurisdiction/region override fields for right invocation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -610,6 +610,18 @@ export type InvokeRightEvent = {
   right: string
   subject: DataSubject
   recaptchaToken?: string
+
+  /**
+   * Overrides the boot-resolved jurisdiction for this invocation only, e.g. from a user-selected
+   * location. Omitted ⇒ the host falls back to its boot-resolved jurisdiction.
+   */
+  jurisdictionCode?: string
+
+  /**
+   * Overrides the boot-resolved region for this invocation only. Omitted ⇒ the host falls back
+   * to its boot-resolved region, if any.
+   */
+  regionCode?: string
 }
 
 /**
@@ -3182,6 +3194,13 @@ export interface Ketch {
    * Get the jurisdiction
    */
   getJurisdiction(): Promise<string>
+
+  /**
+   * Get the jurisdiction configured for a region, or undefined if the region maps to none.
+   *
+   * @param region The region to resolve, e.g. "US-CA"
+   */
+  getJurisdictionForRegion(region: string): Promise<string | undefined>
 
   /**
    * Get the region information


### PR DESCRIPTION
## Description of this change
> Adds two additive fields to the shared `Ketch` contract: `InvokeRightEvent.jurisdictionCode`/`regionCode` (override the boot-resolved jurisdiction/region for a single right invocation) and `Ketch.getJurisdictionForRegion` (resolve a region to its configured jurisdiction). Both are needed so a user-selected location can drive rights rendering and submission, without changing the jurisdiction other flows (consent, subscriptions) use.

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
`npm run lint` and `npm run build` pass in this repo. These are additive, type-only declarations with no runtime code of their own, so I verified them end-to-end against a real consumer instead: linked this build into `ketch-tag` and confirmed `tsc` succeeds against the new fields and its full suite passes (50 suites, 1024 tests, 0 regressions). Reverting to the currently-published `ketch-types` version reproduces compile errors on exactly the three new usages, confirming the change is load-bearing.

## Related issues
KD-17644

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.