### PR TITLE
feat: add Data Subject Details config fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4402,9 +4402,20 @@ export interface RequestsTabRightsListThemeConfig {
   item?: RightsListItemThemeConfig
 }
 
+/**
+ * Preference Center Requests Tab Home View Data Subject Details Theme Configuration
+ */
+
+export interface RequestsTabDataSubjectDetailsThemeConfig {
+  title?: TextThemeConfig
+  description?: TextThemeConfig
+  fields?: FormFieldsThemeConfig
+}
+
 export interface RequestsTabHomeThemeConfig {
   header?: PageTextThemeConfig
   dsrPortalLink?: RequestsTabDsrLinkThemeConfig
+  dataSubjectDetails?: RequestsTabDataSubjectDetailsThemeConfig
   rightsList?: RequestsTabRightsListThemeConfig
 }
 
@@ -5184,11 +5195,28 @@ export interface RequestsTabRightsExperienceLayoutConfig {
 }
 
 /**
+ * Preference Center Requests Tab Home Data Subject Details Experience Layout Configuration
+ */
+
+export interface DataSubjectDetailsTextExperienceLayoutConfig {
+  visible?: boolean
+  useDefaultText?: boolean
+}
+
+export interface RequestsTabDataSubjectDetailsExperienceLayoutConfig {
+  title?: DataSubjectDetailsTextExperienceLayoutConfig
+  description?: DataSubjectDetailsTextExperienceLayoutConfig
+  showSubjectType?: boolean
+  showLocation?: boolean
+}
+
+/**
  * Preference Center Requests Tab Home Experience Layout Configuration
  */
 
 export interface RequestsTabHomeExperienceLayoutConfig {
   header?: PreferenceTabHeaderExperienceLayoutConfig
+  dataSubjectDetails?: RequestsTabDataSubjectDetailsExperienceLayoutConfig
   rights?: RequestsTabRightsExperienceLayoutConfig
 }
 
@@ -5566,6 +5594,15 @@ export interface RequestsTabDsrLinkExperienceContentConfig {
 }
 
 /**
+ * Preferences Center Requests Tab Home Data Subject Details Experience Content Configuration
+ */
+
+export interface RequestsTabDataSubjectDetailsExperienceContentConfig {
+  title?: string
+  description?: string
+}
+
+/**
  * Preferences Center Requests Tab Home Rights Experience Content Configuration
  */
 
@@ -5584,6 +5621,7 @@ export interface RequestsTabRightsExperienceContentConfig {
 export interface RequestsTabHomeExperienceContentConfig {
   header?: PreferenceTabHeaderExperienceContentConfig
   dsrPortalLink?: RequestsTabDsrLinkExperienceContentConfig
+  dataSubjectDetails?: RequestsTabDataSubjectDetailsExperienceContentConfig
   rights?: RequestsTabRightsExperienceContentConfig
 }
 


### PR DESCRIPTION
## Description of this change

> Adds config fields for a new "Data Subject Details" block in the Requests tab of the preference experience: independent location and subject-type visibility, plus a matching theme config.

- `RequestsTabDataSubjectDetailsExperienceLayoutConfig` (`title`, `description`, `showSubjectType`, `showLocation`) on `RequestsTabHomeExperienceLayoutConfig`.
- `RequestsTabDataSubjectDetailsExperienceContentConfig` (`title`, `description`) on `RequestsTabHomeExperienceContentConfig`.
- `RequestsTabDataSubjectDetailsThemeConfig` (`title`, `description`, and `fields: FormFieldsThemeConfig` — reusing the existing field-theme shape rather than a new one) on `RequestsTabHomeThemeConfig`.

All additive, no existing fields changed.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

`npm run build` passes. Verified end-to-end against a consuming app (figurehead) via a local symlink, exercising the new fields through a real form and preview.

## Related issues



## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.