### PR TITLE
feat(types): [KD-17644] add data subject details static content keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5929,6 +5929,7 @@ export interface BaseStaticContentConfig {
   marketing?: string
   maximum_storage?: string
   no_rights_available?: string
+  no_rights_available_for_selected_location?: string
   non_objectable?: string
   not_objected?: string
   object_to_legitimate_interest?: string
@@ -5948,6 +5949,9 @@ export interface BaseStaticContentConfig {
   preference_rights_address_line_two?: string
   preference_rights_cancel_button_text?: string
   preference_rights_country?: string
+  preference_rights_data_subject_details_description_no_location?: string
+  preference_rights_data_subject_details_description_with_location?: string
+  preference_rights_data_subject_details_title?: string
   preference_rights_email?: string
   preference_rights_exit_button_text?: string
   preference_rights_first_name?: string
@@ -5960,6 +5964,7 @@ export interface BaseStaticContentConfig {
   preference_rights_select_country?: string
   preference_rights_select_state_province?: string
   preference_rights_state?: string
+  preference_rights_state_province?: string
   preference_rights_submit_new_request?: string
   preference_rights_thank_you?: string
   preference_rights_we_have_received?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1964,8 +1964,12 @@ export interface Translations {
   preference_rights_last_name?: string
   preference_rights_email?: string
   preference_rights_country?: string
+  preference_rights_data_subject_details_description_no_location?: string
+  preference_rights_data_subject_details_description_with_location?: string
+  preference_rights_data_subject_details_title?: string
   preference_rights_select_country?: string
   preference_rights_state?: string
+  preference_rights_state_province?: string
   preference_rights_thank_you?: string
   preference_rights_we_have_received?: string
   preference_rights_cancel_button_text?: string
@@ -2213,6 +2217,7 @@ export interface Translations {
   verification?: string
   and?: string
   no_rights_available?: string
+  no_rights_available_for_selected_location?: string
 }
 
 /**


### PR DESCRIPTION
## Description of this change
> Adds six new optional string fields to `BaseStaticContentConfig` (the type backing `experiences.content.static`): a `preference_rights_state_province` label distinct from the existing `preference_rights_select_state_province` hint, a data-subject-details title and two description variants (location visible vs. not), and a `no_rights_available_for_selected_location` variant for an unresolved selected location.

Needed before lanyard can reference these keys — see the paired supercargo PR for the same rollout.

## Why is this change being made?
- [x] New feature (non-breaking change that adds functionality)

## How was this tested? How can the reviewer verify your testing?
`npx tsc --noEmit` passes with no errors; existing `npm test` suite passes unaffected. Purely additive optional fields on a TypeScript interface with no runtime logic, so type-checking is the relevant verification here.

## Related issues
Part of the KD-17644 location-based Data Subject Details rollout; no separate GitHub issue.

## Checklist
- [ ] I have added tests to cover my changes. *(N/A — type-only addition, no runtime logic)*
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and OWASP Secure Coding Practices have been observed. *(no security-relevant surface — optional string fields on a type)*
- [ ] I have informed stakeholders of my changes.