### PR TITLE
feat(types): [KD-17927] add Profile tab experience config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5029,6 +5029,26 @@ export interface PreferenceTabHeaderExperienceLayoutConfig {
 }
 
 /**
+ * Preference Center Profile Tab Header Description Experience Layout Configuration
+ */
+
+export interface ProfileTabHeaderDescriptionExperienceLayoutConfig {
+  visible?: boolean
+}
+
+/**
+ * Preference Center Profile Tab Header Experience Layout Configuration
+ *
+ * Distinct from PreferenceTabHeaderExperienceLayoutConfig because the Profile tab's description
+ * can be hidden, which no other tab's can.
+ */
+
+export interface ProfileTabHeaderExperienceLayoutConfig {
+  title?: TextBlockTitleExperienceLayoutConfig
+  description?: ProfileTabHeaderDescriptionExperienceLayoutConfig
+}
+
+/**
  * Preference Center Purposes Tab List Experience Layout Configuration
  */
 
@@ -5076,6 +5096,17 @@ export interface PreferencePurposesTabExperienceLayoutConfig {
   attBanner?: AttBannerExperienceLayoutConfig
   purposeListHeader?: PurposesTabListHeaderExperienceLayoutConfig
   purposeList?: PurposesTabListExperienceLayoutConfig
+  actionButtonUseDefaultText?: boolean
+  actionButtonAction?: ActionButtonAction
+  confirmationMessage?: ConfirmationMessageExperienceLayoutConfig
+}
+
+/**
+ * Preference Center Profile Tab Experience Layout Configuration
+ */
+
+export interface PreferenceProfileTabExperienceLayoutConfig {
+  header?: ProfileTabHeaderExperienceLayoutConfig
   actionButtonUseDefaultText?: boolean
   actionButtonAction?: ActionButtonAction
   confirmationMessage?: ConfirmationMessageExperienceLayoutConfig
@@ -5271,6 +5302,7 @@ export interface PreferenceExperienceTabsLayoutConfig {
   purposes?: PreferencePurposesTabExperienceLayoutConfig
   subscriptions?: PreferenceSubscriptionsTabExperienceLayoutConfig
   requests?: PreferenceRequestsTabExperienceLayoutConfig
+  profile?: PreferenceProfileTabExperienceLayoutConfig
 }
 
 /**
@@ -5486,6 +5518,7 @@ export interface PreferenceNavigationExperienceContentConfig {
   purposesTitle?: string
   subscriptionsTitle?: string
   requestsTitle?: string
+  profileTitle?: string
 }
 
 /**
@@ -5563,6 +5596,16 @@ export interface PreferencePurposesTabExperienceContentConfig {
   attBanner?: AttBannerExperienceContentConfig
   purposeListHeader?: PurposesTabListHeaderExperienceContentConfig
   purposeList?: PurposesTabListExperienceContentConfig
+  actionButtonText?: string
+  confirmationMessage?: string
+}
+
+/**
+ * Preferences Center Profile Tab Experience Content Configuration
+ */
+
+export interface PreferenceProfileTabExperienceContentConfig {
+  header?: PreferenceTabHeaderExperienceContentConfig
   actionButtonText?: string
   confirmationMessage?: string
 }
@@ -5669,6 +5712,7 @@ export interface PreferenceExperienceTabsContentConfig {
   purposes?: PreferencePurposesTabExperienceContentConfig
   subscriptions?: PreferenceSubscriptionsTabExperienceContentConfig
   requests?: PreferenceRequestsTabExperienceContentConfig
+  profile?: PreferenceProfileTabExperienceContentConfig
 }
 
 /**


### PR DESCRIPTION
## Description
> - Add `PreferenceProfileTabExperienceLayoutConfig` and `PreferenceProfileTabExperienceContentConfig`, mirroring the Purposes tab's field names and types.
> - Add `profile` to the preference tabs layout and content configs, and `profileTitle` to the navigation content config.
> - Profile gets its own header layout type, because its description is hideable and no other tab's is.

ticket: https://ketch-com.atlassian.net/browse/KD-17927

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Unblocks the Profile page in the figurehead experience builder, and the lanyard change that reads these values. Today lanyard hardcodes the Profile title and description, so figurehead has nowhere to persist them.

## How was this tested?
Types-only change, no UI. Verified in `ketch-types`:

1. `eslint 'src/**/*.ts'` passes (run raw, since the npm wrapper output was unrelated docs noise)
2. `prettier --check 'src/**/*.ts'` passes
3. `tsc -p .` passes
4. `jest` passes, 2/2
5. Compiled a throwaway probe assigning every new field through `ExperienceLayoutConfig` and `ExperienceContentConfig`. The same shape previously failed with `TS2353: 'profile' does not exist in type 'PreferenceExperienceTabsLayoutConfig'`, and now compiles.

Additive only: every field is optional and nothing was renamed or removed, so no consumer breaks.

## Related issues
https://ketch-com.atlassian.net/browse/KD-17927

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
