### PR TITLE
feat(types): add legitimate interest toggle/signal/default-state fields to Purpose and TCFSystem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -486,15 +486,8 @@ export type PurposeLegitimateInterests = { [key: string]: LegitimateInterestStat
 export type VendorLegitimateInterest = { [key: string]: LegitimateInterestStatus }
 export type VendorLegitimateInterests = { [key: string]: VendorLegitimateInterest }
 
-/**
- * the default consent state applied when no explicit user signal exists
- */
 export type DefaultConsentState = 'opted_in' | 'opted_out' | 'none'
 
-/**
- * the default legitimate interest state applied when no explicit user signal exists.
- * Not LegitimateInterestStatus — this is the literal backend value ('none', not 'not_established').
- */
 export type DefaultLegitimateInterestState = 'established' | 'none'
 
 /**
@@ -921,8 +914,15 @@ export interface Purpose {
    */
   allowLegitimateInterestSignal?: boolean
 
+  /**
+   * the default consent state applied when no explicit user signal exists
+   */
   defaultConsentState?: DefaultConsentState
 
+  /**
+   * the default legitimate interest state applied when no explicit user signal exists.
+   * Deliberately distinct from LegitimateInterestStatus — the backend sends 'none' here, not 'not_established'.
+   */
   defaultLegitimateInterestState?: DefaultLegitimateInterestState
 }
 
@@ -1576,8 +1576,15 @@ export interface TCFSystem {
    */
   allowLegitimateInterestSignal?: boolean
 
+  /**
+   * the default consent state applied when no explicit user signal exists
+   */
   defaultConsentState?: DefaultConsentState
 
+  /**
+   * the default legitimate interest state applied when no explicit user signal exists.
+   * Deliberately distinct from LegitimateInterestStatus — the backend sends 'none' here, not 'not_established'.
+   */
   defaultLegitimateInterestState?: DefaultLegitimateInterestState
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -487,6 +487,17 @@ export type VendorLegitimateInterest = { [key: string]: LegitimateInterestStatus
 export type VendorLegitimateInterests = { [key: string]: VendorLegitimateInterest }
 
 /**
+ * the default consent state applied when no explicit user signal exists
+ */
+export type DefaultConsentState = 'opted_in' | 'opted_out' | 'none'
+
+/**
+ * the default legitimate interest state applied when no explicit user signal exists.
+ * Not LegitimateInterestStatus — this is the literal backend value ('none', not 'not_established').
+ */
+export type DefaultLegitimateInterestState = 'established' | 'none'
+
+/**
  * Consent
  */
 export type Consent = {
@@ -889,6 +900,30 @@ export interface Purpose {
 
   ageBands?: AgeBand[]
   allowsLegitimateInterest?: boolean
+
+  /**
+   * whether the consent toggle should be shown for this purpose
+   */
+  showConsentToggle?: boolean
+
+  /**
+   * whether the legitimate interest toggle should be shown for this purpose
+   */
+  showLegitimateInterestToggle?: boolean
+
+  /**
+   * whether the user is allowed to signal a consent preference for this purpose
+   */
+  allowConsentSignal?: boolean
+
+  /**
+   * whether the user is allowed to signal a legitimate interest preference for this purpose
+   */
+  allowLegitimateInterestSignal?: boolean
+
+  defaultConsentState?: DefaultConsentState
+
+  defaultLegitimateInterestState?: DefaultLegitimateInterestState
 }
 
 /**
@@ -1520,6 +1555,30 @@ export interface TCFSystem {
   name: string
   privacyPolicy?: string
   tcfMetadata?: TCFMetadata
+
+  /**
+   * whether the consent toggle should be shown for this vendor
+   */
+  showConsentToggle?: boolean
+
+  /**
+   * whether the legitimate interest toggle should be shown for this vendor
+   */
+  showLegitimateInterestToggle?: boolean
+
+  /**
+   * whether the user is allowed to signal a consent preference for this vendor
+   */
+  allowConsentSignal?: boolean
+
+  /**
+   * whether the user is allowed to signal a legitimate interest preference for this vendor
+   */
+  allowLegitimateInterestSignal?: boolean
+
+  defaultConsentState?: DefaultConsentState
+
+  defaultLegitimateInterestState?: DefaultLegitimateInterestState
 }
 
 export interface GoogleSystem {


### PR DESCRIPTION
## Description of this change

> Adds the six purpose/vendor consent-and-LI config fields the backend already sends, so lanyard (and any other consumer) can drop its temporary local type shim.
>
> - Added `showConsentToggle`, `showLegitimateInterestToggle`, `allowConsentSignal`, `allowLegitimateInterestSignal`, `defaultConsentState`, `defaultLegitimateInterestState` to `Purpose` and `TCFSystem`
> - Extracted `DefaultConsentState`/`DefaultLegitimateInterestState` as shared named types since the field is duplicated verbatim across both interfaces

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Ran `npm run all` (lint, format-check, test, build, docs) — all clean
> - Verified field names and literal union values match character-for-character against the existing `lanyard` type shim (`src/v2/types/li-toggle-fields.ts`) so that repo can swap to this version with zero code changes
> - Confirmed no duplicate/leaked declarations and no breaking-change risk (all-optional fields, no exact-shape/mapped-type usages of `Purpose`/`TCFSystem` elsewhere in the file)

## Related issues

N/A

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
