### PR TITLE
feat: [KD-18102] add collection id to profile config types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3721,6 +3721,7 @@ export interface ProfileCollectionSection {
  * ProfileCollection
  */
 export interface ProfileCollection {
+  id?: string
   code: string
   name: string
   displayName: string
@@ -6120,6 +6121,7 @@ export interface ExperienceAssociationConfig {
   subscriptionTopicCodes?: string[]
   formIDs?: string[]
   installedSystemIDs?: string[]
+  collectionId?: string
 }
 
 export enum ExperiencePurposeMode {


### PR DESCRIPTION
## Description
> - Add optional `id` to `ProfileCollection` so a collection can be matched to the experience that references it
> - Add optional `collectionId` to `ExperienceAssociationConfig`, which supercargo already emits but was never typed

ticket: https://ketch-com.atlassian.net/browse/KD-18102

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
Types-only change, both fields optional, so existing consumers are unaffected.

`npx tsc --noEmit -p .` clean, eslint clean, prettier clean, jest 1 suite / 2 tests pass.

Groundwork for KD-18102: lanyard's preference center profile tab renders topics from every experience's collection because `profile.collections[]` has no id to match against `experiences.ids.<id>.associations.collectionId`. Verified against a live boot config that the `collectionId` pointer already ships untyped.

## Related issues
https://ketch-com.atlassian.net/browse/KD-18102

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
